### PR TITLE
Compatibility fixes

### DIFF
--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -102,7 +102,7 @@ void CodeGenFunction::EmitVarInitializer(const VarDecl *D) {
   auto T = D->getType();
   if(T->isArrayType()) {
     auto Dest = Builder.CreateConstInBoundsGEP2_32(ConvertTypeForMem(T),
-                                                   GetVarPtr(D), 0, 0, NULL );
+                                                   GetVarPtr(D), 0, 0);
     auto Init = cast<ArrayConstructorExpr>(D->getInit())->getItems();
     for(size_t I = 0; I < Init.size(); ++I) {
       auto Val = EmitRValue(Init[I]);

--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -179,8 +179,8 @@ void CodeGenFunction::EmitCommonBlock(const CommonBlockSet *S) {
   for(auto Obj : S->getObjects()) {
     if(Obj.Var) {
       LocalVariables.insert(std::make_pair(Obj.Var,
-        Builder.CreateStructGEP(ConvertTypeForMem(Obj.Var->getType()), 
-                                Ptr, Idx, NULL)));
+        Builder.CreateStructGEP(nullptr,
+                                Ptr, Idx)));
     }
     ++Idx;
   }

--- a/lib/CodeGen/CGExprAgg.cpp
+++ b/lib/CodeGen/CGExprAgg.cpp
@@ -94,7 +94,7 @@ void CodeGenFunction::EmitAggregateAssignment(const Expr *LHS, const Expr *RHS) 
 }
 
 llvm::Value *CodeGenFunction::EmitAggregateMember(llvm::Value *Agg, const FieldDecl *Field) {
-  return Builder.CreateStructGEP(Agg->getType(), Agg, Field->getIndex());
+  return Builder.CreateStructGEP(nullptr, Agg, Field->getIndex());
 }
 
 void CodeGenFunction::EmitAggregateReturn(const CGFunctionInfo::RetInfo &Info, llvm::Value *Ptr) {

--- a/lib/CodeGen/CGExprComplex.cpp
+++ b/lib/CodeGen/CGExprComplex.cpp
@@ -62,10 +62,10 @@ ComplexValueTy ComplexExprEmitter::VisitComplexConstantExpr(const ComplexConstan
 }
 
 ComplexValueTy CodeGenFunction::EmitComplexLoad(llvm::Value *Ptr, bool IsVolatile) {
-  auto Re = Builder.CreateLoad(Builder.CreateStructGEP(Ptr->getType(),
+  auto Re = Builder.CreateLoad(Builder.CreateStructGEP(nullptr,
                                                        Ptr,
                                                        0), IsVolatile);
-  auto Im = Builder.CreateLoad(Builder.CreateStructGEP(Ptr->getType(),
+  auto Im = Builder.CreateLoad(Builder.CreateStructGEP(nullptr,
                                                        Ptr,
                                                        1), IsVolatile);
   return ComplexValueTy(Re, Im);
@@ -73,9 +73,9 @@ ComplexValueTy CodeGenFunction::EmitComplexLoad(llvm::Value *Ptr, bool IsVolatil
 
 void CodeGenFunction::EmitComplexStore(ComplexValueTy Value, llvm::Value *Ptr,
                                        bool IsVolatile) {
-  Builder.CreateStore(Value.Re, Builder.CreateStructGEP(Ptr->getType(),
+  Builder.CreateStore(Value.Re, Builder.CreateStructGEP(nullptr,
                                                         Ptr,0), IsVolatile);
-  Builder.CreateStore(Value.Im, Builder.CreateStructGEP(Ptr->getType(),
+  Builder.CreateStore(Value.Im, Builder.CreateStructGEP(nullptr,
                                                         Ptr,1), IsVolatile);
 }
 

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -187,8 +187,7 @@ llvm::Value *CodeGenFunction::EmitScalarBinaryExpr(BinaryExpr::Operator Op,
       RHS = EmitIntToInt32Conversion(RHS);
     }
     auto Func = GetIntrinsicFunction(Intrinsic,
-                                     LHS->getType(),
-                                     RHS->getType());
+                                     LHS->getType());
     llvm::Value *PowerArgs[] = {LHS, RHS};
     Result = Builder.CreateCall(Func, PowerArgs);
     break;

--- a/lib/CodeGen/CGSystemLibflang.cpp
+++ b/lib/CodeGen/CGSystemLibflang.cpp
@@ -61,7 +61,7 @@ llvm::Value *CGLibflangSystemRuntime::EmitETIME(CodeGenFunction &CGF, ArrayRef<E
   CGF.EmitCallArg(ArgList, Arr, Func.getInfo()->getArguments()[0]);
   CGF.EmitCallArg(ArgList,
                   CGF.getBuilder().CreateConstInBoundsGEP1_32(
-                    CGF.ConvertTypeForMem(RealTy),Arr, 1, NULL),
+                    CGF.ConvertTypeForMem(RealTy),Arr, 1),
                   Func.getInfo()->getArguments()[1]);
   return CGF.EmitCall(Func.getFunction(), Func.getInfo(), ArgList).asScalar();
 }


### PR DESCRIPTION
I tried to build BLAS and lapack with flang and I found that although flang builds fine with current LLVM master, it fails to compile certain BLAS and lapack source files (assertions failed and segmentation faults) due to upstream API changes in LLVM.
