### PR TITLE
Allow empty 'SAVE' statements

### DIFF
--- a/lib/Sema/Spec.cpp
+++ b/lib/Sema/Spec.cpp
@@ -158,7 +158,7 @@ bool Sema::ApplySaveSpecification(SourceLocation Loc, SourceLocation IDLoc,
 
 bool Sema::ApplySaveSpecification(SourceLocation Loc, SourceLocation IDLoc,
                                   VarDecl *VD) {
-  if(VD->hasStorageSet()) {
+  if(VD->hasStorageSet() && IDLoc.isValid()) {
     if(auto CBSet = dyn_cast<CommonBlockSet>(VD->getStorageSet())) {
       Diags.Report(Loc, diag::err_spec_not_applicable_to_common_block)
         << "save" << getTokenRange(IDLoc);


### PR DESCRIPTION
I encountered this problem while trying to compile lapack tests. Some of them (e.g. clctsx.f test) contain empty SAVE statement. Since gfortran accepts that, I assume that flang should accept that too.

Notice that I don't know flang that well so I can't say whether my approach for fixing this issue is sufficient. I only addressed observable behaviour. Proper review is suggested.
